### PR TITLE
Add .mcp.json to configure the maxmsp MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "maxmsp": {
+      "command": "/Users/gagestohlmann/MaxMSP-MCP-Server/.venv/bin/python",
+      "args": ["/Users/gagestohlmann/MaxMSP-MCP-Server/server.py"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` so any MCP-compatible client (Claude Code, etc.) can automatically register this project's Python-based MCP server (`server.py`, run via the local `.venv`) without manual configuration.

## Test plan
- [x] Confirmed the maxmsp tools load correctly in a Claude Code session rooted in this repo, using this `.mcp.json`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>